### PR TITLE
changed bytes encoding to UTF8 instead of Unicode

### DIFF
--- a/CalculateSHA256Hash/CalculateSHA.cs
+++ b/CalculateSHA256Hash/CalculateSHA.cs
@@ -15,7 +15,7 @@ namespace CalculateSHA256Hash
 
         public static string getHashSha256(string text)
         {
-            byte[] bytes = Encoding.Unicode.GetBytes(text);
+            byte[] bytes = Encoding.UTF8.GetBytes(text);
 
             SHA256Managed hashstring = new SHA256Managed();
 


### PR DESCRIPTION
Unicode is the wrong encoding for converting a string to a series of bytes.

Given a string has the bytes `0xFF 0xFE 0xFA`, the `UNICODE` byte encoding will be:
`0xFF 0x00 0xFE 0x00 0xFA 0x00`

while the UTF8 encoding will be:
`0xFF 0xFE 0xFA`